### PR TITLE
Added `AtomicOptionBox::none()`, since `AtomicOptionBox::new(None)` is not const.

### DIFF
--- a/src/atomic_option_box.rs
+++ b/src/atomic_option_box.rs
@@ -45,6 +45,23 @@ impl<T> AtomicOptionBox<T> {
         abox
     }
 
+    /// Creates a new `AtomicOptionBox` with no value.
+    ///
+    /// Equivalent to `AtomicOptionBox::new(None)`, but can be used in const
+    /// context.
+    ///
+    /// # Examples
+    ///
+    ///     use atomicbox::AtomicOptionBox;
+    ///
+    ///     static GLOBAL_BOX: AtomicOptionBox<u32> = AtomicOptionBox::none();
+    ///
+    pub const fn none() -> Self {
+        Self {
+            ptr: AtomicPtr::new(null_mut()),
+        }
+    }
+
     /// Atomically set this `AtomicOptionBox` to `other` and return the
     /// previous value.
     ///


### PR DESCRIPTION
As titled. This allows one to use `AtomicOptionBox` in a `static`.