### PR TITLE
Support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "atomicbox"
+edition = "2018"
 description = "Safe atomic pointers to boxed data."
 version = "0.3.0"
 authors = ["Jason Orendorff <jason.orendorff@gmail.com>"]

--- a/src/atomic_box.rs
+++ b/src/atomic_box.rs
@@ -1,7 +1,8 @@
-use std::fmt::{self, Debug, Formatter};
-use std::mem::forget;
-use std::ptr::{self, null_mut};
-use std::sync::atomic::{AtomicPtr, Ordering};
+use alloc::boxed::Box;
+use core::fmt::{self, Debug, Formatter};
+use core::mem::forget;
+use core::ptr::{self, null_mut};
+use core::sync::atomic::{AtomicPtr, Ordering};
 
 /// A type that holds a single `Box<T>` value and can be safely shared between
 /// threads.
@@ -156,7 +157,7 @@ impl<T> Debug for AtomicBox<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::Ordering;
+    use core::sync::atomic::Ordering;
     use std::sync::{Arc, Barrier};
     use std::thread::spawn;
 

--- a/src/atomic_option_box.rs
+++ b/src/atomic_option_box.rs
@@ -1,7 +1,8 @@
-use std::fmt::{self, Debug, Formatter};
-use std::mem::forget;
-use std::ptr::{self, null_mut};
-use std::sync::atomic::{AtomicPtr, Ordering};
+use alloc::boxed::Box;
+use core::fmt::{self, Debug, Formatter};
+use core::mem::forget;
+use core::ptr::{self, null_mut};
+use core::sync::atomic::{AtomicPtr, Ordering};
 
 /// A type that holds a single `Option<Box<T>>` value and can be safely shared
 /// between threads.
@@ -207,7 +208,8 @@ impl<T> Debug for AtomicOptionBox<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::Ordering;
+    use alloc::{format, string::String};
+    use core::sync::atomic::Ordering;
 
     #[test]
     fn atomic_option_box_swap_works() {
@@ -255,8 +257,8 @@ mod tests {
 
     #[test]
     fn atomic_box_drops() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        use std::sync::Arc;
+        use alloc::sync::Arc;
+        use core::sync::atomic::{AtomicUsize, Ordering};
 
         struct K(Arc<AtomicUsize>, usize);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@
 //! only operation it supports is `swap`. Still, this is sufficient for some
 //! lock-free data structures, so here it is!
 
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
 mod atomic_box;
 mod atomic_option_box;
 


### PR DESCRIPTION
Makes the crate usable on platforms without a standard library.

Since the tests use threads and barriers, `no_std` is only enabled when `not(test)`.
Consequently I also had to switch to edition 2018 in order to use the `core` crate even when `no_std` isn't set.