### PR TITLE
Add compare_exchange functionality. 

### DIFF
--- a/src/atomic_box_base.rs
+++ b/src/atomic_box_base.rs
@@ -1,0 +1,78 @@
+use std::mem::forget;
+use std::ptr;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+pub(crate) trait PointerConvertible {
+    type Target;
+
+    fn into_raw(b: Self) -> *mut Self::Target;
+    unsafe fn from_raw(raw: *mut Self::Target) -> Self;
+}
+
+pub(crate) struct AtomicBoxBase<B: PointerConvertible> {
+    pub(crate) ptr: AtomicPtr<B::Target>,
+}
+
+impl<B: PointerConvertible> AtomicBoxBase<B> {
+    pub fn new(value: B) -> AtomicBoxBase<B> {
+        let ptr = B::into_raw(value);
+        AtomicBoxBase {
+            ptr: AtomicPtr::new(ptr),
+        }
+    }
+
+    pub fn swap(&self, other: B, order: Ordering) -> B {
+        let mut result = other;
+        self.swap_mut(&mut result, order);
+        result
+    }
+
+    pub fn store(&self, other: B, order: Ordering) {
+        let mut result = other;
+        self.swap_mut(&mut result, order);
+        drop(result);
+    }
+
+    pub fn swap_mut(&self, other: &mut B, order: Ordering) {
+        match order {
+            Ordering::AcqRel | Ordering::SeqCst => {}
+            _ => panic!("invalid ordering for atomic swap"),
+        }
+
+        let other_ptr = B::into_raw(unsafe { ptr::read(other) });
+        let ptr = self.ptr.swap(other_ptr, order);
+        unsafe {
+            ptr::write(other, B::from_raw(ptr));
+        };
+    }
+
+    pub fn into_inner(self) -> B {
+        let last_ptr = self.ptr.load(Ordering::Acquire);
+        forget(self);
+        unsafe { B::from_raw(last_ptr) }
+    }
+
+    pub fn load_pointer(&self, order: Ordering) -> *mut B::Target {
+        self.ptr.load(order)
+    }
+}
+
+impl<B: PointerConvertible> Default for AtomicBoxBase<B>
+where
+    B: Default,
+{
+    /// The default `AtomicBox<T>` value boxes the default `T` value.
+    fn default() -> AtomicBoxBase<B> {
+        AtomicBoxBase::new(Default::default())
+    }
+}
+
+impl<B: PointerConvertible> Drop for AtomicBoxBase<B> {
+    /// Dropping an `AtomicBoxBase<T>` drops the final value stored in it.
+    fn drop(&mut self) {
+        let ptr = self.ptr.load(Ordering::Acquire);
+        unsafe {
+            B::from_raw(ptr);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //! be on the heap.
 
 mod atomic_box;
+mod atomic_box_base;
 mod atomic_option_box;
 
 pub use atomic_box::AtomicBox;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,4 +38,6 @@ mod atomic_box_base;
 mod atomic_option_box;
 
 pub use atomic_box::AtomicBox;
+pub use atomic_box_base::Handle;
+pub use atomic_box_base::HandleReferable;
 pub use atomic_option_box::AtomicOptionBox;


### PR DESCRIPTION
This change was created in collaboration with @ashdnazg.

This change extends the abilities of the atomic box & atomic option box by adding the Handle type, which is an opaque indicator of the current contents of the box, and the following functions:

 * compare_exchange - a function that takes as inputs a handle and a new box. The atomic box compares the handle with its current content, and if they match, the input box is put in the atomic box, and the current held box is returned.
* compare_exchange_mut - like compare exchange, but mutating the input box instead of taking ownership over it.
* compare_exchange_weak - like compare_exchange, but can fail and potentially more effecient on some platforms.
* compare_exchange_weak_mut - like compare_exchange_mut, but can fail and potentially more effecient on some platforms.
* load_handle - returns a handle that represents the current value in the atomic box.
* load_pointer - returns a pointer to the current value in the atomic box. This pointer is unsafe to use.

additionally, adds the following functions to Box<t> / Option<Box<t>>:
* make_handle - returns a handle to the box, which can be used with the compare_exchange* functions once the box/option are stored in an atomic box.

In order to simplify this change, we split recurring logic from AtomicBox/OptionBox to a base class, thus reducing repetition.